### PR TITLE
Add target_latent: pre-encode the pixel path outside the sampling window

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ in-context tokens (RoPE frame 1). Inputs:
 - `vae` + `source_image` *(optional, recommended)* — the blur-proof pixel path: give
   the raw image (and VAE) and the node fits it to the target grid in pixel space.
   Required for `fit_mode: fit`.
+- `target_latent` *(optional, recommended whenever you use the pixel path)* — wire the
+  **same** latent you feed `KSampler.latent_image`. It only tells the node the output
+  resolution ahead of time, so the source can be VAE-encoded here instead of on the first
+  sampling step. Skipping it can cost real speed — see [Pixel path and VRAM](#pixel-path-and-vram).
 - `fit_mode` *(default `fit`)* — how a source fits a mismatched output aspect ratio.
   `fit` = training-matched resample at a centered offset (v1.2); `crop` = center-crop,
   the v1/v1.1-legacy geometry (use with older weights).
@@ -67,7 +71,8 @@ UNETLoader ── LoraLoaderModelOnly (krea2_identity_edit_v1_2 @1.0) ── Kre
 Krea2EditModelPatch ── KSampler.model
 Krea2EditGroundedEncode ── KSampler.positive
 Krea2EditGroundedEncode (empty prompt, same image) ── KSampler.negative
-EmptySD3LatentImage ── KSampler.latent_image
+EmptySD3LatentImage ─┬─ KSampler.latent_image
+                     └─ Krea2EditModelPatch.target_latent   (when using vae + source_image)
 ```
 
 Example workflow in `workflows/`: `krea2_identity_edit.json` — single-image editor by
@@ -94,6 +99,40 @@ default; enable group 2 (toggle its Bypass off) for two-image person-into-scene 
    the main inputs, subject B on the `_b` inputs) rather than adding them one at a time —
    simultaneous placement is currently more reliable than chaining separate edits. Face
    separation is still imperfect and a focus for future versions.
+8. **Wire `target_latent` if you use `vae` + `source_image`** — see below.
+
+## Pixel path and VRAM
+
+The pixel path has to VAE-encode the source at the output resolution. Without
+`target_latent` the node doesn't know that resolution until sampling starts, so the
+encode runs on the first step — and `vae.encode` asks ComfyUI for VRAM at a moment when
+the diffusion model is already resident and mid-run. ComfyUI frees room by partially
+offloading whatever is loaded, the sampler included, and nothing loads it back (it loads
+once, before its loop). The rest of the run then streams weights from CPU on every step.
+
+Wiring `target_latent` moves the encode to node-execution time, restoring the normal
+`VAEEncode → KSampler` order where the sampler evicts the VAE rather than the reverse.
+The encode is cached either way, so this is purely about *when* it happens.
+
+If you have VRAM headroom for the model and the VAE at once, nothing gets offloaded and
+neither wiring costs you anything — which is why this only bites some setups. Wire it
+anyway; it's free.
+
+The console tells you which path you got:
+
+```
+[krea2edit] pre-encoding sources at target 128x128 (before sampling, fit_mode=fit)   <- good
+[krea2edit] NOTE: connect 'target_latent' ...                                        <- encode will land mid-sampling
+```
+
+**Measure over 20+ steps, not 1.** The source still has to be VAE-encoded either way —
+`target_latent` only changes *when*. What it removes is a per-step penalty, so it can
+only show up across many steps. A 1-step run is almost entirely fixed overhead (model
+load, text encode, VAE encode/decode) and will show no difference at all.
+
+A third option is to skip the pixel path entirely: resize your source image to exactly
+the output resolution and feed only `source_latent`. At matched resolution the latent
+path does no resampling and produces the same reference geometry.
 
 ## License / credits
 

--- a/__init__.py
+++ b/__init__.py
@@ -264,6 +264,9 @@ class Krea2EditModelPatch:
             "vae": ("VAE", {"tooltip": "RECOMMENDED with source_image: enables the blur-proof pixel-space path (crop+resize in pixels, encode internally) — immune to input/output resolution mismatches"}),
             "source_image": ("IMAGE", {"tooltip": "source as IMAGE (with vae connected): overrides source_latent with exact pixel-space fitting — fixes blurry results from mismatched resolutions"}),
             "source_image_b": ("IMAGE", {"tooltip": "2nd reference as IMAGE (with vae)"}),
+            # declared last on purpose: appending keeps every existing socket index put,
+            # so workflows saved before this input still reload with their links intact.
+            "target_latent": ("LATENT", {"tooltip": "RECOMMENDED with vae + source_image: wire the SAME latent you feed KSampler.latent_image. Lets the node VAE-encode the source here, before sampling starts, instead of on the first step — otherwise the VAE is pulled onto the GPU mid-sampling and can evict part of the diffusion model, slowing every remaining step on VRAM-tight setups"}),
         }}
 
     RETURN_TYPES = ("MODEL",)
@@ -273,7 +276,7 @@ class Krea2EditModelPatch:
 
     def patch(self, model, source_latent, source_latent_b=None, ref_boost=1.0, ref_boost_a=1.0,
               ref_boost_mask=None, vae=None, source_image=None,
-              source_image_b=None, fit_mode="fit", **_future):
+              source_image_b=None, fit_mode="fit", target_latent=None, **_future):
         if _future:
             print(f"[krea2edit] WARNING: workflow provides inputs this node version does not "
                   f"know ({', '.join(sorted(_future))}). The workflow is newer than the "
@@ -288,11 +291,36 @@ class Krea2EditModelPatch:
 
         px_cache = {}   # pixel-path encoded sources, keyed per target resolution
         mm = model.model  # for process_latent_in on the pixel path
+        state = {"announced": False}
 
         if fit_mode == "fit" and (vae is None or source_image is None):
             print(f"[krea2edit] WARNING: fit_mode='fit' has NO EFFECT — it needs both "
                   f"'vae' and 'source_image' connected (the pixel path). Falling back to the "
                   f"latent crop path.", flush=True)
+
+        # Pre-encode OUTSIDE the sampling window. vae.encode -> load_models_gpu ->
+        # free_memory(keep_loaded=[]), which partially unloads whatever is resident —
+        # including the diffusion model, if the first call lands inside the sampler.
+        # Nothing re-expands it (sampler_helpers loads once, before the loop), so the
+        # rest of the run streams weights from CPU every step. Running the encode here,
+        # at node-execution time, restores the ordinary VAEEncode -> KSampler order
+        # where the sampler evicts the VAE instead of the reverse.
+        primed = None
+        if vae is not None and source_image is not None:
+            if target_latent is not None:
+                Hh, Ww = target_latent["samples"].shape[-2], target_latent["samples"].shape[-1]
+                print(f"[krea2edit] pre-encoding sources at target {Hh}x{Ww} "
+                      f"(before sampling, fit_mode={fit_mode})", flush=True)
+                _fit_encode_image(source_image, vae, Hh, Ww, px_cache, ("a", Hh, Ww), fit_mode)
+                if source_image_b is not None:
+                    _fit_encode_image(source_image_b, vae, Hh, Ww, px_cache, ("b", Hh, Ww), fit_mode)
+                primed = (Hh, Ww)
+            else:
+                print("[krea2edit] NOTE: connect 'target_latent' (the same latent that feeds "
+                      "KSampler.latent_image) to pre-encode the source here instead of on the "
+                      "first sampling step. Without it the VAE is loaded mid-sampling and can "
+                      "evict part of the diffusion model, slowing every remaining step.",
+                      flush=True)
 
         def wrapper(executor, x, timesteps, context, *wargs, **kwargs):
             # ComfyUI signature drift (2026-07-19, commit c9602625 adds ref_latents):
@@ -310,10 +338,18 @@ class Krea2EditModelPatch:
             dm = executor.class_obj  # the SingleStreamDiT instance
             src = src_samples
             if vae is not None and source_image is not None:
-                if not px_cache:
-                    print(f"[krea2edit] pixel path ACTIVE (fit_mode={fit_mode})", flush=True)
                 xx = _to_4d(x)
                 Hh, Ww = xx.shape[-2], xx.shape[-1]
+                # not `if not px_cache` — the cache is already primed when target_latent
+                # is wired, so an explicit one-shot flag is needed to announce once.
+                if not state["announced"]:
+                    state["announced"] = True
+                    print(f"[krea2edit] pixel path ACTIVE (fit_mode={fit_mode})", flush=True)
+                    if primed is not None and primed != (Hh, Ww):
+                        print(f"[krea2edit] WARNING: 'target_latent' is {primed[0]}x{primed[1]} but "
+                              f"sampling is at {Hh}x{Ww} — the pre-encode is unused and the VAE "
+                              f"will run mid-sampling. Wire the SAME latent that feeds KSampler.",
+                              flush=True)
                 lat = mm.process_latent_in(_fit_encode_image(source_image, vae, Hh, Ww, px_cache, ("a", Hh, Ww), fit_mode))
                 if source_image_b is not None:
                     lat = [lat, mm.process_latent_in(_fit_encode_image(source_image_b, vae, Hh, Ww, px_cache, ("b", Hh, Ww), fit_mode))]

--- a/tests/test_pre_encode.py
+++ b/tests/test_pre_encode.py
@@ -1,0 +1,244 @@
+"""Regression tests for the pixel path's VAE-encode timing.
+
+`vae.encode` reaches ComfyUI's `load_models_gpu(..., memory_required=...)`, which calls
+`free_memory()` with an empty `keep_loaded` — so it will partially unload whatever is
+already resident on the device. When the first encode landed *inside* the sampling
+wrapper, that victim was the diffusion model the sampler was in the middle of using, and
+nothing re-expands it (`sampler_helpers` loads once, before the loop). The rest of the run
+then streamed weights from CPU on every step.
+
+`target_latent` moves the encode to node-execution time, before the sampler loads
+anything. These tests pin the observable behavior: WHEN the encode happens, and that it
+still happens exactly once either way.
+
+Self-contained: installs a minimal ComfyUI stub when the real one is not importable, so
+it runs both inside a ComfyUI checkout and standalone.
+
+Run standalone:  python tests/test_pre_encode.py
+Or via pytest:   pytest tests/test_pre_encode.py
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import torch
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PACK = os.path.dirname(_HERE)
+_COMFY_ROOT = os.path.dirname(os.path.dirname(_PACK))   # .../ComfyUI, when installed there
+
+if _COMFY_ROOT not in sys.path:
+    sys.path.insert(0, _COMFY_ROOT)
+
+
+def _install_comfy_stubs():
+    """Only the surface the pack imports at module level. Skipped when real comfy is
+    importable, so this never shadows a genuine ComfyUI checkout."""
+    try:
+        import comfy.patcher_extension  # noqa: F401
+        return
+    except Exception:                                            # noqa: BLE001
+        pass
+
+    class WrappersMP:
+        DIFFUSION_MODEL = "diffusion_model"
+
+    class WrapperExecutor:
+        def __init__(self, original, class_obj, wrappers, idx):
+            self.original, self.class_obj = original, class_obj
+            self.wrappers, self.idx = list(wrappers), idx
+            self.is_last = idx == len(wrappers)
+
+        def execute(self, *args, **kwargs):
+            if self.is_last:
+                return self.original(*args, **kwargs)
+            return self.wrappers[self.idx](self, *args, **kwargs)
+
+    def add_wrapper_with_key(wrapper_type, key, wrapper, options):
+        options.setdefault("wrappers", {}).setdefault(wrapper_type, {}).setdefault(key, []).append(wrapper)
+
+    mods = {}
+    for name in ("comfy", "comfy.patcher_extension", "comfy.utils", "comfy.ldm",
+                 "comfy.ldm.common_dit", "comfy.ldm.flux", "comfy.ldm.flux.layers",
+                 "comfy.ldm.flux.math", "comfy.ldm.modules", "comfy.ldm.modules.attention"):
+        mods[name] = types.ModuleType(name)
+
+    mods["comfy.patcher_extension"].WrappersMP = WrappersMP
+    mods["comfy.patcher_extension"].WrapperExecutor = WrapperExecutor
+    mods["comfy.patcher_extension"].add_wrapper_with_key = add_wrapper_with_key
+    mods["comfy.utils"].common_upscale = lambda s, w, h, *a: s
+    mods["comfy.ldm.common_dit"].pad_to_patch_size = lambda v, _p, **_k: v
+    mods["comfy.ldm.flux.layers"].timestep_embedding = lambda t, d: torch.zeros(t.shape[0], d)
+    mods["comfy.ldm.flux.math"].apply_rope = lambda q, k, _f: (q, k)
+    mods["comfy.ldm.modules.attention"].optimized_attention_masked = lambda *a, **k: None
+    mods["comfy.ldm.modules.attention"].attention_pytorch = lambda *a, **k: None
+
+    for attr, parent, child in (("patcher_extension", "comfy", "comfy.patcher_extension"),
+                                ("utils", "comfy", "comfy.utils"),
+                                ("ldm", "comfy", "comfy.ldm"),
+                                ("common_dit", "comfy.ldm", "comfy.ldm.common_dit"),
+                                ("flux", "comfy.ldm", "comfy.ldm.flux"),
+                                ("modules", "comfy.ldm", "comfy.ldm.modules"),
+                                ("layers", "comfy.ldm.flux", "comfy.ldm.flux.layers"),
+                                ("math", "comfy.ldm.flux", "comfy.ldm.flux.math"),
+                                ("attention", "comfy.ldm.modules", "comfy.ldm.modules.attention")):
+        setattr(mods[parent], attr, mods[child])
+    sys.modules.update(mods)
+
+
+def _load_pack():
+    """Import the pack's __init__.py under a synthetic name (the folder has a hyphen)."""
+    _install_comfy_stubs()
+    spec = importlib.util.spec_from_file_location(
+        "comfyui_krea2edit_pre_encode_test", os.path.join(_PACK, "__init__.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeVAE:
+    """Records every encode so tests can assert on call timing and count."""
+
+    def __init__(self):
+        self.calls = []
+
+    def encode(self, pixels):        # pixels: (B, H, W, C)
+        self.calls.append(tuple(pixels.shape))
+        b, h, w, _ = pixels.shape
+        return torch.zeros(b, 4, h // 8, w // 8)
+
+
+class _FakeInner:
+    def process_latent_in(self, x):
+        return x
+
+
+class _FakeModelPatcher:
+    """Minimal stand-in for ModelPatcher — only what patch() touches."""
+
+    def __init__(self):
+        self.model = _FakeInner()
+        self.model_options = {}
+
+    def clone(self):
+        c = _FakeModelPatcher()
+        c.model = self.model      # share the inner model, like the real clone
+        return c
+
+
+def _latent(h=64, w=64):
+    return {"samples": torch.zeros(1, 4, h, w)}
+
+
+def _image(px=512):
+    return torch.zeros(1, px, px, 3)
+
+
+def _patch(mod, **kwargs):
+    import comfy.patcher_extension as pe
+
+    node = mod.Krea2EditModelPatch()
+    (m,) = node.patch(_FakeModelPatcher(), _latent(), **kwargs)
+    to = m.model_options["transformer_options"]
+    return to["wrappers"][pe.WrappersMP.DIFFUSION_MODEL]["krea2_edit"][0]
+
+
+def _run_steps(wrapper, n=3, h=64, w=64):
+    """Drive the wrapper the way a sampler would: same latent shape, n times."""
+    import comfy.patcher_extension as pe
+
+    for _ in range(n):
+        executor = pe.WrapperExecutor(
+            original=lambda *a, **k: None, class_obj=object(), wrappers=[wrapper], idx=0,
+        )
+        executor.execute(torch.zeros(1, 4, h, w), None, None, None, {})
+
+
+def _stub_forward(mod, seen):
+    mod.krea2_edit_forward = lambda dm, x, t, ctx, src, to, **k: seen.append(src)
+
+
+def test_target_latent_encodes_before_sampling():
+    """The whole point: with target_latent wired, the encode is done by the time patch()
+    returns — i.e. before the sampler loads the diffusion model."""
+    mod = _load_pack()
+    seen = []
+    _stub_forward(mod, seen)
+    vae = _FakeVAE()
+    wrapper = _patch(mod, vae=vae, source_image=_image(), target_latent=_latent())
+
+    assert len(vae.calls) == 1, "source should be encoded during patch(), not later"
+
+    _run_steps(wrapper)
+    assert len(vae.calls) == 1, "sampling must reuse the pre-encode, never re-encode"
+    assert seen[0].shape == (1, 4, 64, 64)
+
+
+def test_without_target_latent_encode_lands_in_the_wrapper():
+    """Legacy path stays functional (and stays the slow one) — documents the contrast."""
+    mod = _load_pack()
+    seen = []
+    _stub_forward(mod, seen)
+    vae = _FakeVAE()
+    wrapper = _patch(mod, vae=vae, source_image=_image())
+
+    assert vae.calls == [], "nothing to encode yet without a known target resolution"
+
+    _run_steps(wrapper)
+    assert len(vae.calls) == 1, "encode happens on the first step, then caches"
+
+
+def test_both_references_are_pre_encoded():
+    mod = _load_pack()
+    seen = []
+    _stub_forward(mod, seen)
+    vae = _FakeVAE()
+    wrapper = _patch(mod, vae=vae, source_image=_image(), source_image_b=_image(),
+                     target_latent=_latent())
+
+    assert len(vae.calls) == 2, "scene and subject refs both pre-encoded"
+
+    _run_steps(wrapper)
+    assert len(vae.calls) == 2
+    assert isinstance(seen[0], list) and len(seen[0]) == 2
+
+
+def test_mismatched_target_latent_falls_back_correctly():
+    """A target_latent that doesn't match what's actually sampled must not corrupt the
+    source — the cache simply misses and the wrapper re-encodes at the real size."""
+    mod = _load_pack()
+    seen = []
+    _stub_forward(mod, seen)
+    vae = _FakeVAE()
+    wrapper = _patch(mod, vae=vae, source_image=_image(), target_latent=_latent(32, 32))
+
+    assert len(vae.calls) == 1                    # primed at the wrong size
+
+    _run_steps(wrapper, n=2, h=64, w=64)
+    assert len(vae.calls) == 2, "one re-encode at the real target size, then cached"
+    assert seen[0].shape == (1, 4, 64, 64), "source must match the sampled grid"
+
+
+def test_target_latent_without_pixel_path_is_inert():
+    """No vae/source_image means the latent path — target_latent must change nothing."""
+    mod = _load_pack()
+    seen = []
+    _stub_forward(mod, seen)
+    wrapper = _patch(mod, target_latent=_latent())
+    _run_steps(wrapper)
+    assert seen[0].shape == (1, 4, 64, 64)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in list(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS  {name}")
+            except Exception as e:                               # noqa: BLE001
+                failures += 1
+                print(f"FAIL  {name}: {type(e).__name__}: {e}")
+    sys.exit(1 if failures else 0)

--- a/workflows/krea2_identity_edit.json
+++ b/workflows/krea2_identity_edit.json
@@ -2,7 +2,7 @@
   "id": "krea2-identity-edit-unified",
   "revision": 0,
   "last_node_id": 110,
-  "last_link_id": 26,
+  "last_link_id": 27,
   "nodes": [
     {
       "id": 29,
@@ -452,6 +452,12 @@
           "shape": 7,
           "type": "IMAGE",
           "link": 20
+        },
+        {
+          "name": "target_latent",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 27
         }
       ],
       "outputs": [
@@ -509,7 +515,8 @@
           "name": "LATENT",
           "type": "LATENT",
           "links": [
-            24
+            24,
+            27
           ]
         }
       ],
@@ -1174,6 +1181,14 @@
       29,
       0,
       "IMAGE"
+    ],
+    [
+      27,
+      82,
+      0,
+      79,
+      7,
+      "LATENT"
     ]
   ],
   "groups": [


### PR DESCRIPTION
## The problem

The pixel path (`vae` + `source_image`) can slow sampling badly on VRAM-tight setups. The encode itself isn't the cost — `px_cache` already means it runs once per target resolution. The problem is *when* it runs.

`vae.encode` reaches `load_models_gpu(..., memory_required=)`, which calls `free_memory()` with an empty `keep_loaded`, so it partially unloads whatever is already resident. Firing from inside the `DIFFUSION_MODEL` wrapper makes that victim the diffusion model the sampler is mid-run on — and nothing re-expands it, since `sampler_helpers.py` loads once, before the loop. Every remaining step then streams weights from CPU.

Setups with headroom for the model and the VAE at once never see this, which is why reports of it are inconsistent.

## The change

New optional `target_latent` input: wire the same latent that feeds `KSampler.latent_image` and `patch()` knows the target grid up front, priming `px_cache` at node-execution time. That restores the ordinary `VAEEncode → KSampler` order, where the sampler evicts the VAE rather than the reverse.

- **Declared last in `optional`**, so no existing socket index moves — workflows saved before this reload with their links intact.
- **Unwired, behavior is unchanged**; the node prints a note instead.
- A `target_latent` that disagrees with the sampled resolution misses the cache and re-encodes at the real size — correct, just not fast — and warns.
- The pixel-path announce moved off `if not px_cache`, which is wrong once the cache is pre-primed, to an explicit one-shot flag.
- Shipped workflow wires `EmptySD3LatentImage` into `target_latent`.

It composes with the `**_future` guard from v1.2.3: `target_latent` is exactly the kind of input that breaks an older install, so anyone on an older pack opening the updated workflow gets the "update the node pack" warning instead of a `TypeError`.

## Tests

`tests/test_pre_encode.py` pins the observable behavior — encode-call count at `patch()` return vs. after driving the wrapper, two-ref priming, the mismatch fallback, and `target_latent` being inert on the latent path. The first test fails without the fix.

It installs a minimal comfy stub when the real one isn't importable, so unlike the existing test it also runs standalone outside a ComfyUI checkout (`python tests/test_pre_encode.py` → 5 PASS). Happy to drop that fallback if you'd rather keep one convention.

`ruff` findings are unchanged from the baseline (same 6 before and after).

## Benchmarking note

This removes a *per-step* penalty, so it only shows up over many steps. A 1-step run is almost entirely fixed overhead (model load, text encode, VAE encode/decode) and will show no difference — the source encode is a fixed cost that moves rather than disappears. Worth saying explicitly, since a 1-step A/B is the natural thing to reach for and it reports "no change".

Two things I measured while chasing this, in case they're useful: the pixel path never produces more tokens than the latent path (equal at matched AR, ~30% fewer on a mismatched one), and the CPU-side fit costs ~34 ms even on a 24MP source. So there's no per-step compute difference between the paths — the VRAM interaction really is the whole story.

## Not included

No version bump or CHANGELOG entry — those are yours to slot into a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)